### PR TITLE
feat: update moengage ios sdk to the latest version 9.17.1

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,7 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 target 'Rudder-Moengage_Example' do
   pod 'Rudder-Moengage', :path => '../'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - MoEngage-iOS-SDK (9.7.0)
-  - Rudder (1.16.0)
-  - Rudder-Moengage (2.1.0):
-    - MoEngage-iOS-SDK (~> 9.5)
+  - MoEngage-iOS-SDK (9.17.1)
+  - Rudder (1.17.0)
+  - Rudder-Moengage (2.1.1):
+    - MoEngage-iOS-SDK (= 9.17.1)
     - Rudder (~> 1.12)
 
 DEPENDENCIES:
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  MoEngage-iOS-SDK: fe5e6039e6381017b756d8cc72b6d9a11112abc1
-  Rudder: 718bc5bf0de0e4d83850dedd792f08e5e2065a0a
-  Rudder-Moengage: 00154e2ef5b17878d46fb9417a706efc0f3d8acd
+  MoEngage-iOS-SDK: 08d54cc0bff2a56ba89db644dd213a6c021d712b
+  Rudder: 3f4ab09638452282a22b96a388b54132dcd3fca8
+  Rudder-Moengage: e168df65ff53333c30a0d4de2f167a96569af229
 
-PODFILE CHECKSUM: ca14697d03a327ae5bc6f60dfe7cd75fb7d5a297
+PODFILE CHECKSUM: 29c179da970177b0db2cf1ad21737f03fbbb6cad
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.14.3

--- a/Example/Rudder-Moengage.xcodeproj/project.pbxproj
+++ b/Example/Rudder-Moengage.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		6003F5BC195388D20070C39A /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5BB195388D20070C39A /* Tests.m */; };
 		71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71719F9D1E33DC2100824A3D /* LaunchScreen.storyboard */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
-		ED949BF729DEC973005DE13A /* RudderConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = ED949BF429DEC973005DE13A /* RudderConfig.plist */; };
 		ED949BF829DEC973005DE13A /* SampleRudderConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = ED949BF529DEC973005DE13A /* SampleRudderConfig.plist */; };
 		ED949BF929DEC973005DE13A /* RudderConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED949BF629DEC973005DE13A /* RudderConfig.swift */; };
 /* End PBXBuildFile section */
@@ -82,7 +81,6 @@
 		ED949BEE29DE90E7005DE13A /* pull_request_template.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = pull_request_template.md; sourceTree = "<group>"; };
 		ED949BEF29DE90E7005DE13A /* dependabot.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = dependabot.yml; sourceTree = "<group>"; };
 		ED949BF029DEC967005DE13A /* Rudder-Moengage_Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Rudder-Moengage_Example-Bridging-Header.h"; sourceTree = "<group>"; };
-		ED949BF429DEC973005DE13A /* RudderConfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = RudderConfig.plist; sourceTree = "<group>"; };
 		ED949BF529DEC973005DE13A /* SampleRudderConfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SampleRudderConfig.plist; sourceTree = "<group>"; };
 		ED949BF629DEC973005DE13A /* RudderConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RudderConfig.swift; sourceTree = "<group>"; };
 		F23B9449A860EDC2806CC29C /* Rudder-Moengage.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "Rudder-Moengage.podspec"; path = "../Rudder-Moengage.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
@@ -248,7 +246,6 @@
 		ED949BF329DEC973005DE13A /* RudderConfig */ = {
 			isa = PBXGroup;
 			children = (
-				ED949BF429DEC973005DE13A /* RudderConfig.plist */,
 				ED949BF529DEC973005DE13A /* SampleRudderConfig.plist */,
 				ED949BF629DEC973005DE13A /* RudderConfig.swift */,
 			);
@@ -340,7 +337,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */,
-				ED949BF729DEC973005DE13A /* RudderConfig.plist in Resources */,
 				ED949BF829DEC973005DE13A /* SampleRudderConfig.plist in Resources */,
 				71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */,
 				6003F5A9195388D20070C39A /* Images.xcassets in Resources */,

--- a/Example/Rudder-Moengage.xcodeproj/project.pbxproj
+++ b/Example/Rudder-Moengage.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MoEngage-iOS-SDK/MoEngageAnalytics.framework/MoEngageAnalytics",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MoEngage-iOS-SDK/MoEngageMessaging.framework/MoEngageMessaging",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MoEngage-iOS-SDK/MoEngageObjCUtils.framework/MoEngageObjCUtils",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MoEngage-iOS-SDK/MoEngageSecurity.framework/MoEngageSecurity",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -405,6 +406,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MoEngageAnalytics.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MoEngageMessaging.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MoEngageObjCUtils.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MoEngageSecurity.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Rudder-Moengage.podspec
+++ b/Rudder-Moengage.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     s.author           = { 'RudderStack' => 'ruchira@rudderlabs.com' }
     s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-moengage-ios.git', :tag => "v#{s.version}" }
 
-    s.ios.deployment_target = '10.0'
+    s.ios.deployment_target = '11.0'
     s.source_files = 'Rudder-Moengage/Classes/**/*'
 
     if defined?($MoengageSDKVersion)

--- a/Rudder-Moengage.podspec
+++ b/Rudder-Moengage.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-moengage_sdk_version = '~> 9.5'
+moengage_sdk_version = '9.17.1'
 rudder_sdk_version = '~> 1.12'
 
 Pod::Spec.new do |s|


### PR DESCRIPTION
# Description

- Updated the minimum iOS SDK version to `11`, as MoEngage now supports this as their minimum iOS version.
- Removed stale reference of the `RudderConfig.plist` file. It was causing a build error.
- Updated the `MoEngage-iOS-SDK` to the latest version `9.17.1`. We did this for two purposes: 
       - First, MoEngage has introduced some breaking changes so our current integration cannot build against the latest version of the MoEngage SDK.
       - Second, to facilitate the generation of the privacy manifest file provided by MoEngage SDK.
- We also fixed the MoEngage iOS SDK version to `9.17.1`, so that we don't have any similar issues, even if breaking changes are introduced in future.
- Updated the MoEngage SDK initialisation code snippet.
        - MoEngage has made it mandatory to use the `dataCenter` field while constructing their `config` object. So now, if this field is missing while initialising the MoEngage SDK then we will explicitly stop initialising the MoEngage SDK and log an error. (Previously we delegated this responsibility to the MoEngage SDK.)
        - MoEngage has introduced support for different types of log messages. We have added support for that as well.

